### PR TITLE
pc - fix mutation testing frontend

### DIFF
--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -46,6 +46,7 @@ export function hasRole(currentUser, role) {
 
   if ("data" in currentUser &&
     "root" in currentUser.data &&
+    currentUser.data.root != null &&
     "rolesList" in currentUser.data.root) {
     return currentUser.data.root.rolesList.includes(role);
   }

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -46,7 +46,6 @@ export function hasRole(currentUser, role) {
 
   if ("data" in currentUser &&
     "root" in currentUser.data &&
-    currentUser.data.root != null &&
     "rolesList" in currentUser.data.root) {
     return currentUser.data.root.rolesList.includes(role);
   }

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -176,6 +176,9 @@ describe("utils/currentUser tests", () => {
 
             const testFixture2 = { data: { root: { rolesList: [ ] } }};
             expect(hasRole(testFixture2, "ROLE_SAMPLE")).toBeFalsy();
+
+            const testFixtureNullRoot = { data: { root: null }};
+            expect(hasRole(testFixture2, "ROLE_SAMPLE")).toBeFalsy();
         });
 
     });

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -173,12 +173,12 @@ describe("utils/currentUser tests", () => {
         test('When rolesList is inside data: root, the correct results are returned', async () => {
             const testFixture1 = { data: { root: { rolesList: [ "ROLE_SAMPLE"] } }};
             expect(hasRole(testFixture1, "ROLE_SAMPLE")).toBeTruthy();
-
+          
             const testFixture2 = { data: { root: { rolesList: [ ] } }};
             expect(hasRole(testFixture2, "ROLE_SAMPLE")).toBeFalsy();
 
             const testFixtureNullRoot = { data: { root: null }};
-            expect(hasRole(testFixture2, "ROLE_SAMPLE")).toBeFalsy();
+            expect(hasRole(testFixtureNullRoot, "ROLE_SAMPLE")).toBeFalsy();
         });
 
     });

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
@@ -6,17 +6,24 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 
+import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
-@Api(description="User information (admin only)")
+@Api(description = "User information (admin only)")
 @RequestMapping("/api/admin/users")
 @RestController
 public class UsersController extends ApiController {
@@ -34,5 +41,29 @@ public class UsersController extends ApiController {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @ApiOperation(value = "Get user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/get")
+    public User users(
+            @ApiParam("id") @RequestParam Long id)
+            throws JsonProcessingException {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+        return user;
+    }
+
+    @ApiOperation(value = "Delete a user (admin)")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("/delete")
+    public Object deleteUser_Admin(
+            @ApiParam("id") @RequestParam Long id) {
+              User user = userRepository.findById(id)
+          .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+          userRepository.delete(user);
+
+        return genericMessage("User with id %s deleted".formatted(id));
     }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/ControllerTestCase.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/ControllerTestCase.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.gauchoride;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,6 +35,6 @@ public abstract class ControllerTestCase {
 
   protected Map<String, Object> responseToJson(MvcResult result) throws UnsupportedEncodingException, JsonProcessingException {
     String responseString = result.getResponse().getContentAsString();
-    return mapper.readValue(responseString, Map.class);
+    return mapper.readValue(responseString,  new TypeReference<Map<String,Object>>() {});
   }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -1,7 +1,6 @@
 package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
-import edu.ucsb.cs156.gauchoride.controllers.UsersController;
 import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
@@ -14,14 +13,19 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -71,4 +75,96 @@ public class UsersControllerTests extends ControllerTestCase {
     assertEquals(expectedJson, responseString);
 
   }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__returns_a_user_that_exists() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+      User user1 = User.builder().email("cgaucho@ucsb.edu").id(42L).build();
+      when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=42"))
+              .andExpect(status().isOk()).andReturn();
+
+      // assert
+
+      verify(userRepository, times(1)).findById(42L);
+      String expectedJson = mapper.writeValueAsString(user1);
+      String responseString = response.getResponse().getContentAsString();
+      assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void api_users__admin_logged_in__search_for_user_that_does_not_exist() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+
+      when(userRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/admin/users/get?id=7"))
+              .andExpect(status().isNotFound()).andReturn();
+
+      // assert
+
+      // verify(userRepository, times(1)).findById(7L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("User with id 7 not found", json.get("message"));
+  }
+
+
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_delete_a_user() throws Exception {
+          // arrange
+          User user1 = User.builder().email("cgaucho@ucsb.edu").id(15L).build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(user1));
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).delete(any());
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 deleted", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                  throws Exception {
+          // arrange
+
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+          // act
+          MvcResult response = mockMvc.perform(
+                          delete("/api/admin/users/delete?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
+
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -147,7 +147,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = { "ADMIN", "USER" })
   @Test
-  public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+  public void admin_tries_to_delete_non_existant_user_and_gets_right_error_message()
                   throws Exception {
           // arrange
 


### PR DESCRIPTION
This instructor PR contains more suggestions for how to get the frontend mutation coverage to pass.

We remove one line from the "hack" that was put in because of the various shapes the currentUser json can take.  