### PR TITLE
pc - fix mutation coverage issue; test wasn't checking whether admin …

### DIFF
--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -193,7 +193,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
           // assert
           verify(userRepository, times(1)).findById(15L);
-          verify(userRepository, times(1)).save(any());
+          verify(userRepository, times(1)).save(eq(userAfter));
 
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled admin status", json.get("message"));
@@ -226,7 +226,7 @@ public class UsersControllerTests extends ControllerTestCase {
 
           // assert
           verify(userRepository, times(1)).findById(15L);
-          verify(userRepository, times(1)).save(any());
+          verify(userRepository, times(1)).save(eq(userAfter));
 
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 has toggled admin status", json.get("message"));


### PR DESCRIPTION
In this instructor PR, we show how to overcome a mutation testing coverage issue by asserting that the admin status was actually toggled.