### PR TITLE
pc - set up separate workflow for incremental mutation testing 

### DIFF
--- a/.github/workflows/03-gh-pages-pr-table.yml
+++ b/.github/workflows/03-gh-pages-pr-table.yml
@@ -119,4 +119,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3
+        token: ${{ github.token }}

--- a/.github/workflows/03-gh-pages-pr-table.yml
+++ b/.github/workflows/03-gh-pages-pr-table.yml
@@ -120,4 +120,6 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v3
-        token: ${{ github.token }}
+        with:
+          branch: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/33-frontend-incremental-mutation-testing.yml
+++ b/.github/workflows/33-frontend-incremental-mutation-testing.yml
@@ -3,6 +3,7 @@ name: "33-frontend-incremental-mutation-testing: Stryker JS Mutation Testing (Ja
 # This workflow pulls incremental mutation testing results
 # if they exist for the named branch, and then 
 # uses those incremental results to run mutation testing faster.
+# Reference: https://stryker-mutator.io/docs/stryker-js/incremental/
 
 on:
   workflow_dispatch:
@@ -27,14 +28,52 @@ jobs:
       - uses: actions/checkout@v2
         with: 
           fetch-depth: 2
+      - name: Figure out Branch nam
+        id: get-branch-name
+        run: | 
+            GITHUB_HEAD_REF="${GITHUB_HEAD_REF}"
+            echo GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+            GITHUB_REF_CLEANED=${GITHUB_REF/refs\/heads\//}
+            echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+            GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED//\//-}
+            echo GITHUB_REF_CLEANED=${GITHUB_REF_CLEANED}
+            BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_CLEANED}}"
+            echo "branch_name=${BRANCH}"
+            echo "branch_name=${BRANCH}" >> "$GITHUB_ENV"    
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          branch: ${{ env.branch_name }}}
+          name: stryker-incremental-${{env.branch_name}}.json
+          path: frontend/reports/stryker-incremental-${{env.branch_name}}.json
+          check_artifacts: true
+          if_no_artifact_found: warn
+      - name: Debugging output one
+        run: |
+          ls -lRt frontend/reports
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+
       - run: npm ci
         working-directory: ./frontend
-      - run: npx stryker run
+      - run: npx stryker run --incremental --incrementalFile reports/stryker-incremental-${{env.branch_name}}.json
         working-directory: ./frontend
+
+      - name: Debugging output two
+        run: |
+          ls -lRt frontend/reports
+
+      - name: Upload stryker incremental file to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: stryker-incremental-${{env.branch_name}}
+          path: frontend/reports/stryker-incremental-${{env.branch_name}}.json
+
       - name: Upload stryker report to Artifacts
         if: always() # always upload artifacts, even if tests fail
         uses: actions/upload-artifact@v2

--- a/.github/workflows/33-frontend-incremental-mutation-testing.yml
+++ b/.github/workflows/33-frontend-incremental-mutation-testing.yml
@@ -1,7 +1,13 @@
-name: "34-frontend-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
+name: "33-frontend-incremental-mutation-testing: Stryker JS Mutation Testing (JavaScript/Jest)"
+
+# This workflow pulls incremental mutation testing results
+# if they exist for the named branch, and then 
+# uses those incremental results to run mutation testing faster.
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths: [frontend/**]
   push:
     branches: [main]
     paths: [frontend/**]


### PR DESCRIPTION
In this PR, we split the mutation testing into two separate workflows:

* One that runs on every PR to main which does incremental testing
* One that runs on push to main that does full mutation testing

The reason is that the app has grown to the point where Stryker mutation testing takes more than an hour on some of our code bases.   