### PR TITLE
pc - path to restore artifact should be the directory only

### DIFF
--- a/.github/workflows/33-frontend-incremental-mutation-testing.yml
+++ b/.github/workflows/33-frontend-incremental-mutation-testing.yml
@@ -47,7 +47,7 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: ${{ env.branch_name }}
           name: stryker-incremental-${{env.branch_name}}.json
-          path: frontend/reports/stryker-incremental-${{env.branch_name}}.json
+          path: frontend/reports
           check_artifacts: true
           if_no_artifact_found: warn
       - name: Debugging output one


### PR DESCRIPTION
In this PR, we fix a bug with the incremental workflow for stryker.

The path, when restoring an artifact, should be only the directory, not the full filename.