### PR TITLE
pc - update path in 33-frontend-pr-mutation-testing.yml

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -57,7 +57,7 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           branch: main
           name: stryker-incremental-${{env.pr_number}}.json
-          path: frontend/history/stryker-incremental-${{ env.pr_number }}.json
+          path: frontend/history
           check_artifacts: true
           if_no_artifact_found: warn
     


### PR DESCRIPTION
Per Ben Ye:

I think I might have found a bug with the `33-frontend-pr-mutation-testing` workflow: the path parameter of the "Download artifact" step (line 61) should be just frontend/history instead of frontend/history/stryker-incremental-${{ [env.pr](http://env.pr/)_number }}.json
The documentation for "action-download-artifact" says that the "path" parameter specifies a directory.
My team was running into issues with this github action, so I dug into it. I also tested this by making a branch (ben-frontend-workflow-debug in team03-6pm-1) with the change, and manually running the action twice.