### PR TITLE
pc - add rider role to User entity and user fixtures

### DIFF
--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -12,7 +12,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": "ucsb.edu",
             "admin": true,
-            "driver": false
+            "driver": false,
+            "rider": false
         },
         {
             "id": 2,
@@ -26,7 +27,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": null,
             "admin": false,
-            "driver": true
+            "driver": true,
+            "rider": false
         },
         {
             "id": 3,
@@ -40,7 +42,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": null,
             "admin": false,
-            "driver": false
+            "driver": false,
+            "rider": true
         }
     ]
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/User.java
@@ -28,7 +28,10 @@ public class User {
   private boolean emailVerified;
   private String locale;
   private String hostedDomain;
-  private boolean admin;
+  @Builder.Default
+  private boolean admin=false;
   @Builder.Default
   private boolean driver=false;
+  @Builder.Default
+  private boolean rider=false;
 }


### PR DESCRIPTION
In this PR, we add a rider field to the User entity, in preparation for having three settable roles (admin, driver, rider).

We also add this field to the userFixtures on the frontend.

This PR will have no impact on current end users, but enables future features to be built, including the ability for admins to toggle the rider role.