### PR TITLE
Pc add rider toggle endpoint

### DIFF
--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -12,7 +12,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": "ucsb.edu",
             "admin": true,
-            "driver": false
+            "driver": false,
+            "rider": false
         },
         {
             "id": 2,
@@ -26,7 +27,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": null,
             "admin": false,
-            "driver": true
+            "driver": true,
+            "rider": false
         },
         {
             "id": 3,
@@ -40,7 +42,8 @@ const usersFixtures = {
             "locale": "en",
             "hostedDomain": null,
             "admin": false,
-            "driver": false
+            "driver": false,
+            "rider": true
         }
     ]
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/UsersController.java
@@ -15,7 +15,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -79,7 +78,7 @@ public class UsersController extends ApiController {
 
         user.setAdmin(!user.getAdmin());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled admin status".formatted(id));
+        return genericMessage("User with id %s has toggled admin status to %s".formatted(id, user.getAdmin()));
     }
 
     @Operation(summary = "Toggle the driver field")
@@ -91,7 +90,18 @@ public class UsersController extends ApiController {
 
         user.setDriver(!user.getDriver());
         userRepository.save(user);
-        return genericMessage("User with id %s has toggled driver status".formatted(id));
+        return genericMessage("User with id %s has toggled driver status to %s".formatted(id, user.getDriver()));
     }
 
+    @Operation(summary = "Toggle the rider field")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/toggleRider")
+    public Object toggleRider( @Parameter(name = "id") @RequestParam Long id){
+        User user = userRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        user.setRider(!user.getRider());
+        userRepository.save(user);
+        return genericMessage("User with id %s has toggled rider status to %s".formatted(id, user.getRider()));
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/entities/User.java
@@ -28,7 +28,10 @@ public class User {
   private boolean emailVerified;
   private String locale;
   private String hostedDomain;
-  private boolean admin;
+  @Builder.Default
+  private boolean admin=false;
   @Builder.Default
   private boolean driver=false;
+  @Builder.Default
+  private boolean rider=false;
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -341,4 +341,93 @@ public class UsersControllerTests extends ControllerTestCase {
           Map<String, Object> json = responseToJson(response);
           assertEquals("User with id 15 not found", json.get("message"));
   }
+
+
+  // rider toggle tests
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_rider_status_of_a_user_from_false_to_true() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .rider(false)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .rider(true)
+          .build();
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleRider?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled rider status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_can_toggle_rider_status_of_a_user_from_true_to_false() throws Exception {
+          // arrange
+          User userBefore = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .rider(true)
+          .build();
+
+          User userAfter = User.builder()
+          .email("cgaucho@ucsb.edu")
+          .id(15L)
+          .rider(false)
+          .build();
+
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.of(userBefore));
+          when(userRepository.save(eq(userAfter))).thenReturn(userAfter);
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleRider?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isOk()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+          verify(userRepository, times(1)).save(userAfter);
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 has toggled rider status", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+  @Test
+  public void admin_tries_to_toggle_rider_for_non_existant_user_and_gets_right_error_message() throws Exception {
+          // arrange
+        
+    
+          when(userRepository.findById(eq(15L))).thenReturn(Optional.empty());
+          
+          // act
+          MvcResult response = mockMvc.perform(
+                          post("/api/admin/users/toggleRider?id=15")
+                                          .with(csrf()))
+                          .andExpect(status().isNotFound()).andReturn();
+
+          // assert
+          verify(userRepository, times(1)).findById(15L);
+         
+
+          Map<String, Object> json = responseToJson(response);
+          assertEquals("User with id 15 not found", json.get("message"));
+  }
 }

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/UsersControllerTests.java
@@ -196,7 +196,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+          assertEquals("User with id 15 has toggled admin status to true", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -229,7 +229,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled admin status", json.get("message"));
+          assertEquals("User with id 15 has toggled admin status to false", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -284,7 +284,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+          assertEquals("User with id 15 has toggled driver status to true", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -317,7 +317,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled driver status", json.get("message"));
+          assertEquals("User with id 15 has toggled driver status to false", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -373,7 +373,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled rider status", json.get("message"));
+          assertEquals("User with id 15 has toggled rider status to true", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })
@@ -406,7 +406,7 @@ public class UsersControllerTests extends ControllerTestCase {
           verify(userRepository, times(1)).save(userAfter);
 
           Map<String, Object> json = responseToJson(response);
-          assertEquals("User with id 15 has toggled rider status", json.get("message"));
+          assertEquals("User with id 15 has toggled rider status to false", json.get("message"));
   }
 
   @WithMockUser(roles = { "ADMIN", "USER" })


### PR DESCRIPTION
This PR is a mix of this PR https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-2/pull/47 by @AlejandroRR16  and new commits by @pconrad 

From the original PR: 
>  I implemented the toggle rider button in backend. This allows an admin to toggle rider on user, which gives that user the rider role. 

In addition, the responses from the toggle endpoints  for admin, driver, and rider have all been changed to include the new value of the toggled field. 