### PR TITLE
Update 99-copy-issues.yml

### DIFF
--- a/.github/workflows/99-copy-issues.yml
+++ b/.github/workflows/99-copy-issues.yml
@@ -63,14 +63,6 @@ jobs:
           body: |
             Copied from ${{ env.STARTER }}/issues/${{ matrix.value.number }}
 
-      - name: Create comment on old issue
-        uses: peter-evans/create-or-update-comment@v3
-        with:
-          repository: ${{ env.STARTER_NAME }}
-          issue-number: ${{ matrix.value.number }}
-          body: |
-            Copied to https://github.com/${{ github.repository }}/issues/${{ steps.new-issue.outputs.number}}
-           
       - run: |
           echo "Copied issue ${{ github.event.inputs.issue_number }} from ${{ env.STARTER }}/issues/${{ github.event.inputs.issue_number }}" >> "$GITHUB_STEP_SUMMARY"
           echo " to issue ${{ steps.new-issue.outputs.number }} at url ${{ steps.new-issue.outputs.html_url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/99-copy-issues.yml
+++ b/.github/workflows/99-copy-issues.yml
@@ -47,6 +47,7 @@ jobs:
         uses: actions/checkout@v3.5.2
          
       - name: Create issue
+        id: new-issue
         uses: dacbd/create-issue-action@main
         with:
             token: ${{ github.token }}
@@ -54,7 +55,24 @@ jobs:
             body: ${{ matrix.value.body }}
             labels: ${{ matrix.value.labels }}
         
+      - name: Create comment on new issue
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          issue-number: ${{ steps.new-issue.outputs.number }}
+          body: |
+            Copied from ${{ env.STARTER }}/issues/${{ matrix.value.number }}
 
+      - name: Create comment on old issue
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          repository: ${{ env.STARTER }}
+          issue-number: ${{ matrix.value.number }}
+          body: |
+            Copied to https://github.com/${{ github.repository }}/issues/${{ steps.new-issue.outputs.number}}
+           
+      - run: |
+          echo "Copied issue ${{ github.event.inputs.issue_number }} from ${{ env.STARTER }}/issues/${{ github.event.inputs.issue_number }}" >> "$GITHUB_STEP_SUMMARY"
+          echo " to issue ${{ steps.new-issue.outputs.number }} at url ${{ steps.new-issue.outputs.html_url }}" >> "$GITHUB_STEP_SUMMARY"
  
            
 

--- a/.github/workflows/99-copy-issues.yml
+++ b/.github/workflows/99-copy-issues.yml
@@ -4,6 +4,7 @@ name: 99 - Copy issues from starter repo
 env:
     GH_TOKEN: ${{ github.token }}
     STARTER: https://github.com/ucsb-cs156/proj-gauchoride
+    STARTER_NAME: ucsb-cs156/proj-gauchoride
 on:
   workflow_dispatch:
 
@@ -65,7 +66,7 @@ jobs:
       - name: Create comment on old issue
         uses: peter-evans/create-or-update-comment@v3
         with:
-          repository: ${{ env.STARTER }}
+          repository: ${{ env.STARTER_NAME }}
           issue-number: ${{ matrix.value.number }}
           body: |
             Copied to https://github.com/${{ github.repository }}/issues/${{ steps.new-issue.outputs.number}}


### PR DESCRIPTION
In this PR, we add logic to workflow 99 that will add two way links in comments when copying issues.

# Screenshots

In the created issue, there will be a comment like this one:

<img width="583" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/1119017/7a3baa76-b33c-4bdc-a8c2-0bffe32eaf80">


In the original issue, there will be this annotation on the issue:

<img width="875" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/1119017/09c034a8-0158-45e8-8fa2-8822cdd53092">
