### PR TITLE
pc - update swagger csrf setting in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,7 +17,8 @@ spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_
 spring.security.oauth2.client.registration.google.scope=email,profile
 
 management.endpoints.web.exposure.include=mappings
-springfox.documentation.swagger.v2.path=/api/docs
+springdoc.swagger-ui.csrf.enabled=true
+
 spring.jpa.hibernate.ddl-auto=update
 app.admin.emails=${ADMIN_EMAILS:${env.ADMIN_EMAILS:phtcon@ucsb.edu}}
 


### PR DESCRIPTION
In this PR we add this line to `application.properties`, which is necessary for swagger to work with POST, PUT, DELETE requests:

```
springdoc.swagger-ui.csrf.enabled=true
```

See also: https://stackoverflow.com/a/62285262