### PR TITLE
pc - do not show swagger links on prod

### DIFF
--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -4,4 +4,4 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 
-app.showSwaggerUILink=true
+app.showSwaggerUILink=false


### PR DESCRIPTION
In this PR, we modify application.properties so that a link to swagger does not appear in the navbar on production (only in dev.)

Swagger is still available; it just isn't shown in the navbar.