### PR TITLE
Additional Driver Information Backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -7,7 +7,9 @@ import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.models.DriverInfo;
 
+import java.sql.Driver;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +26,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name = "Driver Information")
-@RequestMapping("/api/drivers/all")
+@RequestMapping("/api/drivers")
 @RestController
 public class DriversController extends ApiController{
     @Autowired
@@ -35,20 +37,34 @@ public class DriversController extends ApiController{
 
     @Operation(summary = "Get a list of all drivers")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
-    @GetMapping("")
+    @GetMapping("/all")
     public ResponseEntity<String> drivers()
             throws JsonProcessingException {
 
                 Iterable<User> drivers=userRepository.findByDriver(true);
 
-                
-                
-                
-
-                
         String body = mapper.writeValueAsString(drivers);
         return ResponseEntity.ok().body(body);
     }
 
+    @Operation(summary = "Get user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public DriverInfo driver(
+            @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        DriverInfo driverInfo = new DriverInfo();
+
+        if(user.getDriver()){
+            driverInfo.setIsDriver(true);
+            driverInfo.setEmail(user.getEmail());
+            driverInfo.setFamilyName(user.getFamilyName());
+            driverInfo.setGivenName(user.getGivenName());
+        }
+        return driverInfo;
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/DriverInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/DriverInfo.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.gauchoride.models;
+
+import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DriverInfo {
+  private String givenName;
+  private String familyName;
+  private String email;
+  private boolean isDriver;
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.models.DriverInfo;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 
@@ -36,8 +37,14 @@ public class DriversControllerTests extends ControllerTestCase {
   UserRepository userRepository;
 
   @Test
-  public void users__logged_out() throws Exception {
+  public void users__logged_out_all() throws Exception {
     mockMvc.perform(get("/api/drivers/all"))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void users__logged_out_get() throws Exception {
+    mockMvc.perform(get("/api/drivers/get?id=42"))
         .andExpect(status().is(403));
   }
 
@@ -78,4 +85,82 @@ public class DriversControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void returns_no_info_for_non_drivers() throws Exception {
+
+                // arrange
+
+                User u = currentUserService.getCurrentUser().getUser();
+                User user1 = User.builder().email("cgaucho@ucsb.edu").id(42L).build();
+                DriverInfo driverInfo = DriverInfo.builder().isDriver(false).build();
+                when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/drivers/get?id=42"))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(userRepository, times(1)).findById(42L);
+                String expectedJson = mapper.writeValueAsString(driverInfo);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void returns_info_for_drivers() throws Exception {
+
+                // arrange
+
+                User u = currentUserService.getCurrentUser().getUser();
+                User user1 = User.builder().email("cgaucho@ucsb.edu")
+                .familyName("gaucho")
+                .givenName("Chris")
+                .id(42L)
+                .driver(true)
+                .build();
+                DriverInfo driverInfo = DriverInfo.builder()
+                .isDriver(true)
+                .email("cgaucho@ucsb.edu")
+                .familyName("gaucho")
+                .givenName("Chris")
+                .build();
+                when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/drivers/get?id=42"))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(userRepository, times(1)).findById(42L);
+                String expectedJson = mapper.writeValueAsString(driverInfo);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void search_for_user_that_does_not_exist() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+
+      when(userRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/drivers/get?id=7"))
+              .andExpect(status().isNotFound()).andReturn();
+
+      // assert
+
+      // verify(userRepository, times(1)).findById(7L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("User with id 7 not found", json.get("message"));
+  }
 }


### PR DESCRIPTION
Makes a few changes to the drivers controller. 
1. Changes controller mapping to /api/drivers from /api/drivers/all, the one function that was there still has the same api, api/drivers/all (had mapping "", now "/all". \
2. Added function that gets user from the userRepository and returns a DTO with all information we may want from a driver. If the user searched is not a driver, it will return null values (for security/privacy).

API mappings
<img width="1086" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/b5e4157a-d9eb-4416-9f6d-35a072e1e894">

This id is the id of a driver
<img width="1280" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/be05467d-1048-4fe7-b150-9e1b6963b56d">

This id is the id of a non driver (but still a user)
<img width="1280" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/95b5e778-92aa-4672-abc5-fd9cea33e684">
