### PR TITLE
Additional Driver Information frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,8 @@ import ShiftEditPage from "main/pages/Shift/ShiftEditPage";
 import ShiftIndexPage from "main/pages/Shift/ShiftIndexPage";
 import DriverPage from "main/pages/DriverPage";
 
+import DriverInfoPage from "main/pages/DriverInfoPage";
+
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -50,6 +52,9 @@ function App() {
         }
         {
           (hasRole(currentUser, "ROLE_ADMIN")  || hasRole(currentUser, "ROLE_RIDER") )&& <Route exact path="/ride/edit/:id" element={<RideRequestEditPage />} />
+        }
+        {
+          (hasRole(currentUser, "ROLE_ADMIN")  || hasRole(currentUser, "ROLE_RIDER") )&& <Route exact path="/driverInfo/:id" element={<DriverInfoPage />} />
         }
         {
           (hasRole(currentUser, "ROLE_DRIVER") || hasRole(currentUser, "ROLE_ADMIN"))  && <Route exact path="/chat" element={<ChatPage />} />

--- a/frontend/src/main/components/Driver/DriverInfo.js
+++ b/frontend/src/main/components/Driver/DriverInfo.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Card from 'react-bootstrap/Card';
+
+function DriverInfo({ info }) {
+  return (
+    <Card data-testid="DriverInfo">
+      <Card.Body>
+      {info.isDriver ? (
+          <Card.Title>{info.givenName + " " + info.familyName + ", Email: " + info.email}</Card.Title>
+        ) : (
+          <Card.Title>
+            Searched user was not a driver
+          </Card.Title>
+        )}
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default DriverInfo;
+
+
+
+
+

--- a/frontend/src/main/components/Shift/ShiftTable.js
+++ b/frontend/src/main/components/Shift/ShiftTable.js
@@ -1,5 +1,6 @@
 import React from "react";
 import OurTable, { ButtonColumn } from "main/components/OurTable";
+import { Link } from "react-router-dom";
 
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsDelete, onDeleteSuccess } from "main/utils/shiftUtils"
@@ -48,11 +49,17 @@ export default function ShiftTable({
         },
         {
             Header: 'Driver',
-            accessor: 'driverID'
+            accessor: 'driverID',
+            Cell: ({ value }) => (
+                <Link to={`/driverInfo/${value}`}>{value}</Link>
+              ),
         },
         {
             Header: 'Backup driver',
             accessor: 'driverBackupID',
+            Cell: ({ value }) => (
+                <Link to={`/driverInfo/${value}`}>{value}</Link>
+              ),
         }
     ];
 

--- a/frontend/src/main/pages/DriverInfoPage.js
+++ b/frontend/src/main/pages/DriverInfoPage.js
@@ -25,7 +25,6 @@ export default function DriverInfoPage() {
                 <Button
                     variant="primary"
                     href="/shift/"
-                    style={{ float: "right" }}
                 >
                     Return
                 </Button>

--- a/frontend/src/main/pages/DriverInfoPage.js
+++ b/frontend/src/main/pages/DriverInfoPage.js
@@ -1,0 +1,49 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import { useBackend } from "main/utils/useBackend";
+import DriverInfo from "main/components/Driver/DriverInfo";
+import { Button } from 'react-bootstrap';
+
+export default function DriverInfoPage() {
+    let { id } = useParams();
+
+    const { data: info, _error, _status } =
+      useBackend(
+        // Stryker disable next-line all : don't test internal caching of React Query
+        [`/api/drivers/get?id=${id}`],
+        {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+          method: "GET",
+          url: `/api/drivers/get`,
+          params: {
+            id
+          }
+        }
+      );
+
+      const returnButton = () => {
+            return (
+                <Button
+                    variant="primary"
+                    href="/shift/"
+                    style={{ float: "right" }}
+                >
+                    Return
+                </Button>
+            )
+    }
+
+  
+      return (
+          <BasicLayout>
+              <div className="pt-2">
+              {returnButton()}
+                <h1>Additional information</h1>
+                  {info && <DriverInfo info={ info }/>}
+              </div>
+          </BasicLayout>
+      )
+  }
+
+
+
+

--- a/frontend/src/tests/pages/DriverInfoPage.test.js
+++ b/frontend/src/tests/pages/DriverInfoPage.test.js
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import DriverInfoPage from "main/pages/DriverInfoPage";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("DriverInfoPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <DriverInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("on submit, not driver", async () => {
+        
+        const queryClient = new QueryClient();
+        const info = {
+            "isDriver": false
+        };
+
+        axiosMock.onGet("/api/drivers/get").reply(200, info);
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                   <DriverInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText("Searched user was not a driver")).toBeInTheDocument();
+        });
+        expect(screen.getByText("Additional information")).toBeInTheDocument();
+        expect(screen.getByText("Return")).toBeInTheDocument();
+    });
+
+    test("on submit, is driver", async () => {
+        
+        const queryClient = new QueryClient();
+        const info = {
+            "isDriver": true,
+            "email": "example@gmail.com",
+            "givenName": "gName",
+            "familyName": "fName"
+        };
+
+        axiosMock.onGet("/api/drivers/get").reply(200, info);
+
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                   <DriverInfoPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText("gName fName, Email: example@gmail.com")).toBeInTheDocument();
+        });
+
+    });
+});

--- a/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/controllers/DriversController.java
@@ -7,7 +7,9 @@ import edu.ucsb.cs156.gauchoride.entities.User;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 
 import edu.ucsb.cs156.gauchoride.errors.EntityNotFoundException;
+import edu.ucsb.cs156.gauchoride.models.DriverInfo;
 
+import java.sql.Driver;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +26,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name = "Driver Information")
-@RequestMapping("/api/drivers/all")
+@RequestMapping("/api/drivers")
 @RestController
 public class DriversController extends ApiController{
     @Autowired
@@ -35,20 +37,34 @@ public class DriversController extends ApiController{
 
     @Operation(summary = "Get a list of all drivers")
     @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
-    @GetMapping("")
+    @GetMapping("/all")
     public ResponseEntity<String> drivers()
             throws JsonProcessingException {
 
                 Iterable<User> drivers=userRepository.findByDriver(true);
 
-                
-                
-                
-
-                
         String body = mapper.writeValueAsString(drivers);
         return ResponseEntity.ok().body(body);
     }
 
+    @Operation(summary = "Get user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || hasRole('ROLE_DRIVER') || hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public DriverInfo driver(
+            @Parameter(name = "id", description = "Long, id number of user to get", example = "1", required = true) @RequestParam Long id)
+            throws JsonProcessingException {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+        DriverInfo driverInfo = new DriverInfo();
+
+        if(user.getDriver()){
+            driverInfo.setIsDriver(true);
+            driverInfo.setEmail(user.getEmail());
+            driverInfo.setFamilyName(user.getFamilyName());
+            driverInfo.setGivenName(user.getGivenName());
+        }
+        return driverInfo;
+    }
 
 }

--- a/src/main/java/edu/ucsb/cs156/gauchoride/models/DriverInfo.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/models/DriverInfo.java
@@ -1,0 +1,19 @@
+package edu.ucsb.cs156.gauchoride.models;
+
+import edu.ucsb.cs156.gauchoride.entities.ChatMessage;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class DriverInfo {
+  private String givenName;
+  private String familyName;
+  private String email;
+  private boolean isDriver;
+}

--- a/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/controllers/DriversControllerTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.gauchoride.controllers;
 
 import edu.ucsb.cs156.gauchoride.ControllerTestCase;
 import edu.ucsb.cs156.gauchoride.entities.User;
+import edu.ucsb.cs156.gauchoride.models.DriverInfo;
 import edu.ucsb.cs156.gauchoride.repositories.UserRepository;
 import edu.ucsb.cs156.gauchoride.testconfig.TestConfig;
 
@@ -36,8 +37,14 @@ public class DriversControllerTests extends ControllerTestCase {
   UserRepository userRepository;
 
   @Test
-  public void users__logged_out() throws Exception {
+  public void users__logged_out_all() throws Exception {
     mockMvc.perform(get("/api/drivers/all"))
+        .andExpect(status().is(403));
+  }
+
+  @Test
+  public void users__logged_out_get() throws Exception {
+    mockMvc.perform(get("/api/drivers/get?id=42"))
         .andExpect(status().is(403));
   }
 
@@ -78,4 +85,82 @@ public class DriversControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
+        @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void returns_no_info_for_non_drivers() throws Exception {
+
+                // arrange
+
+                User u = currentUserService.getCurrentUser().getUser();
+                User user1 = User.builder().email("cgaucho@ucsb.edu").id(42L).build();
+                DriverInfo driverInfo = DriverInfo.builder().isDriver(false).build();
+                when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/drivers/get?id=42"))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(userRepository, times(1)).findById(42L);
+                String expectedJson = mapper.writeValueAsString(driverInfo);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+        @Test
+        public void returns_info_for_drivers() throws Exception {
+
+                // arrange
+
+                User u = currentUserService.getCurrentUser().getUser();
+                User user1 = User.builder().email("cgaucho@ucsb.edu")
+                .familyName("gaucho")
+                .givenName("Chris")
+                .id(42L)
+                .driver(true)
+                .build();
+                DriverInfo driverInfo = DriverInfo.builder()
+                .isDriver(true)
+                .email("cgaucho@ucsb.edu")
+                .familyName("gaucho")
+                .givenName("Chris")
+                .build();
+                when(userRepository.findById(eq(42L))).thenReturn(Optional.of(user1));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/drivers/get?id=42"))
+                        .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(userRepository, times(1)).findById(42L);
+                String expectedJson = mapper.writeValueAsString(driverInfo);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void search_for_user_that_does_not_exist() throws Exception {
+
+      // arrange
+
+      User u = currentUserService.getCurrentUser().getUser();
+
+      when(userRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+      // act
+      MvcResult response = mockMvc.perform(get("/api/drivers/get?id=7"))
+              .andExpect(status().isNotFound()).andReturn();
+
+      // assert
+
+      // verify(userRepository, times(1)).findById(7L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("EntityNotFoundException", json.get("type"));
+      assertEquals("User with id 7 not found", json.get("message"));
+  }
 }


### PR DESCRIPTION
Changes the shift index page, and adds a link on the id of a driver that directly links to a new driverInfoPage, which displays more information about this driver, currently full name and email. This page also has a return button to go back to shift index page.

Example of links:
<img width="1000" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/434eae7d-9e0b-4ec4-bfbb-733cee4651bd">

Example of driver:
<img width="1280" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/8b6848b2-6b7d-406a-a472-5381d7a5634b">

Example of non-driver:
<img width="1280" alt="image" src="https://github.com/ucsb-cs156/proj-gauchoride/assets/114381138/c423d68d-cd7a-4911-a06a-c01297c110f0">

